### PR TITLE
test: pure な制約URL処理の単体テストを最小導入する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,18 +64,21 @@ AI 加工は任意機能であり、主要価値は「認証なしでも軽く�
 基本コマンド:
 
 - `npm run dev`
+- `npm test`
 - `npm run build`
 - `npm run lint`
 - `npm run start`
 
 確認の優先順:
 1. 変更箇所のローカル動作確認
-2. `npm run lint`
-3. `npm run build`
+2. `npm test`（`test` script が存在し、変更内容に関連する場合）
+3. `npm run lint`
+4. `npm run build`
 
 テストについて:
-- 現時点で整備済みの自動テストはない
+- 現時点では `npm test` で実行できる最小限の自動テストがある
 - 重要ロジックを触る場合は、最低限のテスト追加を検討する
+- pure logic、validation、helper、変換処理を触る変更では `npm test` を確認対象に含める
 - テストを追加しない場合は、手動確認内容を明記する
 
 ## Implementation Rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
+        "tsx": "^4.20.6",
         "typescript": "^5"
       }
     },
@@ -309,6 +310,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3102,6 +3545,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3688,6 +4173,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6258,6 +6758,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --experimental-strip-types test/run-tests.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "node --experimental-strip-types test/run-tests.ts"
+    "test": "npx tsx test/run-tests.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -24,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.20.6",
     "typescript": "^5"
   }
 }

--- a/src/components/PolishForm.tsx
+++ b/src/components/PolishForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/phraseConstraints";
 import { isValidBucketId, validatePhraseText } from "@/lib/phraseValidation";
 import { hasSupabaseConfig, supabaseClient } from "@/lib/supabaseClient";
+import { splitTextWithUrls } from "@/lib/urlText";
 
 type Phrase = {
   id: string;
@@ -45,7 +46,6 @@ type ToastItem = {
 const bucketStorageKey = "phrasebridge_bucket_id";
 const writeKeyStorageKey = "phrasebridge_write_key";
 const toastDurationMs = 2400;
-const urlPattern = /https?:\/\/[^\s]+/g;
 
 // 共有ID/編集キー用の簡易URLセーフ変換
 const toBase64Url = (bytes: Uint8Array): string => {
@@ -98,58 +98,33 @@ const formatDateTime = (value: string): string => {
   return date.toLocaleString("ja-JP", { hour12: false });
 };
 
-const splitTrailingPunctuation = (value: string): { url: string; trailing: string } => {
-  const validUrlMatch = value.match(/^https?:\/\/[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]*/);
-  const url = validUrlMatch?.[0] ?? value;
-
-  return {
-    url,
-    trailing: value.slice(url.length),
-  };
-};
-
 const renderTextWithLinks = (value: string): ReactNode => {
-  const matches = Array.from(value.matchAll(urlPattern));
+  const segments = splitTextWithUrls(value);
 
-  if (matches.length === 0) {
+  if (segments.length === 1 && segments[0].type === "text") {
     return value;
   }
 
   const nodes: ReactNode[] = [];
-  let lastIndex = 0;
 
-  matches.forEach((match, index) => {
-    const rawUrl = match[0];
-    const matchIndex = match.index ?? 0;
-
-    if (lastIndex < matchIndex) {
-      nodes.push(value.slice(lastIndex, matchIndex));
+  segments.forEach((segment, index) => {
+    if (segment.type === "text") {
+      nodes.push(segment.value);
+      return;
     }
-
-    const { url, trailing } = splitTrailingPunctuation(rawUrl);
 
     nodes.push(
       <a
-        key={`${url}-${matchIndex}-${index}`}
-        href={url}
+        key={`${segment.value}-${index}`}
+        href={segment.value}
         target="_blank"
         rel="noreferrer"
         className="break-all text-sky-700 underline underline-offset-2 hover:text-sky-800"
       >
-        {url}
+        {segment.value}
       </a>,
     );
-
-    if (trailing) {
-      nodes.push(trailing);
-    }
-
-    lastIndex = matchIndex + rawUrl.length;
   });
-
-  if (lastIndex < value.length) {
-    nodes.push(value.slice(lastIndex));
-  }
 
   return nodes;
 };

--- a/src/lib/phraseValidation.ts
+++ b/src/lib/phraseValidation.ts
@@ -2,7 +2,7 @@ import {
   bucketIdMinLength,
   extraInstructionMaxLength,
   phraseMaxLength,
-} from "./phraseConstraints.ts";
+} from "./phraseConstraints";
 
 // PhraseBridge の入力制約で再利用する pure な validation 群。
 // route 固有の認可や DB 検証はここに含めない。

--- a/src/lib/phraseValidation.ts
+++ b/src/lib/phraseValidation.ts
@@ -2,7 +2,7 @@ import {
   bucketIdMinLength,
   extraInstructionMaxLength,
   phraseMaxLength,
-} from "@/lib/phraseConstraints";
+} from "./phraseConstraints.ts";
 
 // PhraseBridge の入力制約で再利用する pure な validation 群。
 // route 固有の認可や DB 検証はここに含めない。

--- a/src/lib/urlText.ts
+++ b/src/lib/urlText.ts
@@ -1,0 +1,51 @@
+export const urlPattern = /https?:\/\/[^\s]+/g;
+
+type TextSegment = {
+  type: "text" | "link";
+  value: string;
+};
+
+export const splitTrailingPunctuation = (value: string): { url: string; trailing: string } => {
+  const validUrlMatch = value.match(/^https?:\/\/[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]*/);
+  const url = validUrlMatch?.[0] ?? value;
+
+  return {
+    url,
+    trailing: value.slice(url.length),
+  };
+};
+
+export const splitTextWithUrls = (value: string): TextSegment[] => {
+  const matches = Array.from(value.matchAll(urlPattern));
+
+  if (matches.length === 0) {
+    return [{ type: "text", value }];
+  }
+
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+
+  matches.forEach((match) => {
+    const rawUrl = match[0];
+    const matchIndex = match.index ?? 0;
+
+    if (lastIndex < matchIndex) {
+      segments.push({ type: "text", value: value.slice(lastIndex, matchIndex) });
+    }
+
+    const { url, trailing } = splitTrailingPunctuation(rawUrl);
+    segments.push({ type: "link", value: url });
+
+    if (trailing) {
+      segments.push({ type: "text", value: trailing });
+    }
+
+    lastIndex = matchIndex + rawUrl.length;
+  });
+
+  if (lastIndex < value.length) {
+    segments.push({ type: "text", value: value.slice(lastIndex) });
+  }
+
+  return segments;
+};

--- a/test/phraseValidation.test.ts
+++ b/test/phraseValidation.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+
+import {
+  bucketIdMinLength,
+  extraInstructionMaxLength,
+  phraseMaxLength,
+} from "../src/lib/phraseConstraints.ts";
+import {
+  isSha256Hex,
+  isValidBucketId,
+  validateExtraInstruction,
+  validatePhraseText,
+} from "../src/lib/phraseValidation.ts";
+
+export const phraseValidationTests: Array<{ name: string; run: () => void }> = [
+  {
+    name: "isValidBucketId は最小文字数以上で true を返す",
+    run: () => {
+      assert.equal(isValidBucketId("a".repeat(bucketIdMinLength - 1)), false);
+      assert.equal(isValidBucketId("a".repeat(bucketIdMinLength)), true);
+    },
+  },
+  {
+    name: "isSha256Hex は 64 文字の16進文字列だけを許可する",
+    run: () => {
+      assert.equal(isSha256Hex("a".repeat(64)), true);
+      assert.equal(isSha256Hex("g".repeat(64)), false);
+      assert.equal(isSha256Hex("a".repeat(63)), false);
+    },
+  },
+  {
+    name: "validatePhraseText は空文字と上限超過を弾く",
+    run: () => {
+      assert.equal(validatePhraseText("   "), "フレーズを入力してください。");
+      assert.equal(
+        validatePhraseText("a".repeat(phraseMaxLength + 1)),
+        `フレーズは${phraseMaxLength}文字以内で入力してください。`,
+      );
+      assert.equal(validatePhraseText("ok"), null);
+    },
+  },
+  {
+    name: "validateExtraInstruction は上限超過のみ弾く",
+    run: () => {
+      assert.equal(validateExtraInstruction("a".repeat(extraInstructionMaxLength)), null);
+      assert.equal(
+        validateExtraInstruction("a".repeat(extraInstructionMaxLength + 1)),
+        `追加指示は${extraInstructionMaxLength}文字以内で入力してください。`,
+      );
+    },
+  },
+];

--- a/test/run-tests.ts
+++ b/test/run-tests.ts
@@ -1,0 +1,24 @@
+import { phraseValidationTests } from "./phraseValidation.test.ts";
+import { urlTextTests } from "./urlText.test.ts";
+
+type TestCase = {
+  name: string;
+  run: () => void;
+};
+
+const tests: TestCase[] = [...phraseValidationTests, ...urlTextTests];
+
+let passed = 0;
+
+for (const testCase of tests) {
+  try {
+    testCase.run();
+    passed += 1;
+    console.log(`PASS ${testCase.name}`);
+  } catch (error) {
+    console.error(`FAIL ${testCase.name}`);
+    throw error;
+  }
+}
+
+console.log(`\n${passed}/${tests.length} tests passed`);

--- a/test/urlText.test.ts
+++ b/test/urlText.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+
+import { splitTextWithUrls, splitTrailingPunctuation } from "../src/lib/urlText.ts";
+
+export const urlTextTests: Array<{ name: string; run: () => void }> = [
+  {
+    name: "splitTrailingPunctuation は URL 末尾の日本語句読点を分離する",
+    run: () => {
+      assert.deepEqual(splitTrailingPunctuation("https://example.com/path。"), {
+        url: "https://example.com/path",
+        trailing: "。",
+      });
+    },
+  },
+  {
+    name: "splitTextWithUrls は本文と URL と句読点を順序どおりに分割する",
+    run: () => {
+      assert.deepEqual(splitTextWithUrls("確認 https://example.com/path。お願いします"), [
+        { type: "text", value: "確認 " },
+        { type: "link", value: "https://example.com/path" },
+        { type: "text", value: "。お願いします" },
+      ]);
+    },
+  },
+];

--- a/test/urlText.test.ts
+++ b/test/urlText.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 
 import { splitTextWithUrls, splitTrailingPunctuation } from "../src/lib/urlText.ts";
 
+const joinSegments = (
+  segments: ReturnType<typeof splitTextWithUrls>,
+): string => segments.map((segment) => segment.value).join("");
+
 export const urlTextTests: Array<{ name: string; run: () => void }> = [
   {
     name: "splitTrailingPunctuation は URL 末尾の日本語句読点を分離する",
@@ -20,6 +24,67 @@ export const urlTextTests: Array<{ name: string; run: () => void }> = [
         { type: "link", value: "https://example.com/path" },
         { type: "text", value: "。お願いします" },
       ]);
+    },
+  },
+  {
+    name: "splitTextWithUrls は URL がない文字列をそのまま text segment にする",
+    run: () => {
+      assert.deepEqual(splitTextWithUrls("URL を含まない通常テキストです"), [
+        { type: "text", value: "URL を含まない通常テキストです" },
+      ]);
+    },
+  },
+  {
+    name: "splitTextWithUrls は文頭 URL を link と後続 text に分割する",
+    run: () => {
+      assert.deepEqual(splitTextWithUrls("https://example.com/path の確認"), [
+        { type: "link", value: "https://example.com/path" },
+        { type: "text", value: " の確認" },
+      ]);
+    },
+  },
+  {
+    name: "splitTextWithUrls は文末 URL を前置 text と link に分割する",
+    run: () => {
+      assert.deepEqual(splitTextWithUrls("詳細はこちら https://example.com/path"), [
+        { type: "text", value: "詳細はこちら " },
+        { type: "link", value: "https://example.com/path" },
+      ]);
+    },
+  },
+  {
+    name: "splitTextWithUrls は複数 URL を順序どおりに分割する",
+    run: () => {
+      assert.deepEqual(
+        splitTextWithUrls("A https://a.example/x?y=1 B https://b.example/z#top。"),
+        [
+          { type: "text", value: "A " },
+          { type: "link", value: "https://a.example/x?y=1" },
+          { type: "text", value: " B " },
+          { type: "link", value: "https://b.example/z#top" },
+          { type: "text", value: "。" },
+        ],
+      );
+    },
+  },
+  {
+    name: "splitTextWithUrls は ASCII 記号を含む URL を link として保持する",
+    run: () => {
+      assert.deepEqual(
+        splitTextWithUrls("確認 https://example.com/a-_.~/?q=1&x=y#frag!"),
+        [
+          { type: "text", value: "確認 " },
+          { type: "link", value: "https://example.com/a-_.~/?q=1&x=y#frag!" },
+        ],
+      );
+    },
+  },
+  {
+    name: "splitTextWithUrls の segment を再連結すると元文字列に戻る",
+    run: () => {
+      const value = "確認 https://example.com/path。次は https://example.org?q=1#top";
+
+      assert.equal(joinSegments(splitTextWithUrls(value)), value);
     },
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
## Summary
- pure validation の最小テストを追加
- URL 整形 / リンク分割の pure helper とテストを追加
- npm test をローカル実行可能な形で追加

## Verification
- npm test
- npm run lint

## Notes
- npm run lint では既存の react-hooks/exhaustive-deps 警告 1 件が残ります
- Node の --experimental-strip-types 警告は出ますが、テストは通過しています

Closes #6