### PR TITLE
docs: canonicalize invariants and make checks behavioral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,25 +39,24 @@ AI 加工は任意機能であり、主要価値は「認証なしでも軽く�
 
 ## External Integration Rules
 ### Supabase
-- クライアント側では `src/lib/supabaseClient.ts` を使う
-- サーバ側の削除・cleanup では `src/lib/supabaseAdmin.ts` を使う
-- `SUPABASE_SERVICE_ROLE_KEY` はクライアントへ渡さない
-- `page.tsx` や UI コンポーネントで直接 `createClient` しない
+- Supabase の接続・権限境界に関する硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: SUPABASE_CLIENT_ADMIN_SEPARATION -->
+  <!-- invariant: SERVICE_ROLE_KEY_SERVER_ONLY -->
 
 ### Gemini API
-- Gemini 呼び出しは `src/app/api/polish/route.ts` に集約する
-- UI から直接 Gemini を呼ばない
-- 入力制約、許可モード、エラーハンドリングは API 境界で維持する
-- 事実追加禁止、固有名詞や数値の改変禁止など、この repo 固有の出力ポリシーを壊さない
+- Gemini API 境界と出力忠実性に関する硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: AI_API_BOUNDARY -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
 
 ### localStorage / ブラウザ API
-- `bucket_id` と `write_key` の保持はクライアント側で行う
-- `write_key` の平文は DB に保存しない
-- サーバへ送る値は `write_key_hash` を使う
+- 鍵の役割と保存禁止条件は `docs/invariants.yml` を参照する
+  <!-- invariant: KEY_ROLE_SEPARATION -->
+  <!-- invariant: WRITE_KEY_NOT_IN_DB -->
 
 ### PWA
 - `public/manifest.webmanifest` と `public/sw.js` を前提にする
-- API レスポンスをキャッシュする変更は慎重に扱う
+- API キャッシュに関する硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: NO_SW_API_CACHE -->
 - PWA 対応を壊す変更では、ホーム画面追加と起動確認まで行う
 
 ## Build / Lint / Test Commands
@@ -88,16 +87,17 @@ AI 加工は任意機能であり、主要価値は「認証なしでも軽く�
 - `@/*` エイリアスを使う
 - TypeScript の型を維持する
 - 既存の camelCase / PascalCase 命名を崩さない
-- 入力上限、保存件数上限、有効期限などの既存制約を変更する場合は、影響を明示する
+- 入力上限、保存件数上限、有効期限などの硬い制約は `docs/invariants.yml` を参照する
+  <!-- invariant: LIMITS_STABILITY -->
 
 この repo で特に守ること:
-- `bucket_id` は共有キー、`write_key` は編集キー、`write_key_hash` はサーバ送信用という役割を混ぜない
-- 削除と cleanup の保護条件を緩めない
+- 鍵の役割、削除・cleanup、AI 出力、PolishForm の局所変更に関する硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: KEY_ROLE_SEPARATION -->
+  <!-- invariant: PROTECT_DELETE_CLEANUP -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
+  <!-- invariant: CORE_LOCAL_CHANGE_ONLY -->
 - AI 加工が失敗しても通常の保存・共有フローは壊さない
 - `src/components/PolishForm.tsx` は 900 行超の中核ファイルとして扱う
-- `src/components/PolishForm.tsx` への変更は局所的に行い、依頼範囲に必要な最小差分を優先する
-- `src/components/PolishForm.tsx` を触る際に、関係のない整形や大規模リファクタを同時に行わない
-- `src/components/PolishForm.tsx` の大規模分割や再構成は、通常の機能修正とは分けて別タスクで扱う
 
 ## Documentation Rules
 task 開始時は docs 全体を走査せず、最小限の文脈から開始します。
@@ -161,19 +161,21 @@ task 開始時は docs 全体を走査せず、最小限の文脈から開始し
 Supabase や Gemini の実接続確認ができない場合は、その旨を明記します。
 
 ## Repo-specific Risks or Forbidden Patterns
-- UI で service role key 相当の処理を扱わない
+- 硬い禁止条件は `docs/invariants.yml` を参照する
+  <!-- invariant: SERVICE_ROLE_KEY_SERVER_ONLY -->
+  <!-- invariant: WRITE_KEY_NOT_IN_DB -->
+  <!-- invariant: AI_API_BOUNDARY -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
+  <!-- invariant: NO_SW_API_CACHE -->
 - `src/components/PolishForm.tsx` にさらに外部接続やサーバ責務を追加しすぎない
-- `write_key` の平文を DB 保存しない
-- API ルートの入力検証を外さない
-- AI プロンプトの安全制約を軽くしない
-- `sw.js` の変更で API キャッシュを入れない
 
 特に注意する変更:
-- `bucket_id` / `write_key` / `write_key_hash` の仕様変更
-- phrase 上限件数や有効期限の変更
-- Supabase の権限まわり
-- Gemini のプロンプト方針変更
-- PWA キャッシュ戦略の変更
+- 注意対象と対応する正本 ID は `docs/invariants.yml` を参照する
+  <!-- invariant: KEY_ROLE_SEPARATION -->
+  <!-- invariant: LIMITS_STABILITY -->
+  <!-- invariant: SERVICE_ROLE_KEY_SERVER_ONLY -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
+  <!-- invariant: NO_SW_API_CACHE -->
 
 ## Environment Variables
 この repo で前提となる環境変数:

--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -59,9 +59,12 @@ AI 加工は保存フローの補助機能であり、必須ではない。通�
 - 1 画面完結を優先する
 - UI にサーバ責務や秘密情報を寄せすぎない
 - 外部接続は既存の API / lib 分離を守る
-- `bucket_id` と `write_key` と `write_key_hash` の役割を混ぜない
-- AI 加工は API 境界で入力制約と出力ポリシーを守る
+- 鍵の役割と AI 境界の硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: KEY_ROLE_SEPARATION -->
+  <!-- invariant: AI_API_BOUNDARY -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
 - `PolishForm.tsx` は中核だが、大規模再構成は通常タスクと分ける
+  <!-- invariant: CORE_LOCAL_CHANGE_ONLY -->
 
 ## UX 方針
 
@@ -76,19 +79,17 @@ AI 加工は保存フローの補助機能であり、必須ではない。通�
 - 認証機能の追加
 - 複雑な状態管理の導入
 - AI を前提にした保存フローへの変更
-- UI からの service role key 相当処理
-- API レスポンスの PWA キャッシュ
+- UI 権限処理と PWA API キャッシュの硬い禁止条件は `docs/invariants.yml` を参照する
+  <!-- invariant: SERVICE_ROLE_KEY_SERVER_ONLY -->
+  <!-- invariant: NO_SW_API_CACHE -->
 - 要確認: 共有リンク、招待、履歴検索などの高度共有機能
 
 ## 制約
 
-- `bucket_id` は 22 文字以上
-- `write_key` 平文は DB に保存しない
-- `write_key_hash` はサーバ送信用
-- フレーズは 2000 文字以内
-- `extraInstruction` は 500 文字以内
-- 期限切れは 7 日
-- 1 bucket あたり最大 200 件
+- 制約値、write key 保存、サーバ送信用キーの硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: LIMITS_STABILITY -->
+  <!-- invariant: WRITE_KEY_NOT_IN_DB -->
+  <!-- invariant: KEY_ROLE_SEPARATION -->
 
 ## 今後の拡張余地
 

--- a/docs/development_summary.md
+++ b/docs/development_summary.md
@@ -1,0 +1,23 @@
+# Development Summary
+
+## 2026-06-13 docs/invariants
+
+### 変更
+
+- `docs/invariants.yml` を追加し、repo 固有の硬い不変条件を正本化した。
+- `docs/engineering-principles.md`、`docs/ai-context.md`、`AGENTS.md` の硬い不変条件本文を正本 ID 参照へ整理した。
+- `docs/repo-map.md` に `docs/invariants.yml` を参照先として追加した。
+
+### 確認
+
+- `docs/invariants.yml` は必須フィールド `id`、`statement`、`severity`、`triggers` を各項目に持つ。
+- 旧ファイル側に `<!-- invariant: ... -->` コメントを残し、正本 ID で双方向 grep できる形にした。
+- アプリコード `src/` 配下は変更していない。
+- 既存 Node 環境で `docs/invariants.yml` の必須フィールド、`severity`、`ref` アンカーなし、10 件の ID を機械検査した。
+- `npx --yes js-yaml docs/invariants.yml` で YAML parse が通った。
+- `npm run lint` が通った。
+- `npm run build` が通った。
+
+### 未確認
+
+- 判定保留にした硬い不変条件はない。

--- a/docs/engineering-principles.md
+++ b/docs/engineering-principles.md
@@ -14,7 +14,8 @@
   - 依頼と無関係な整形、大規模分割、命名変更、責務再配置を同時に行わない
 - follow existing patterns
   - 既存の App Router、API ルート、Supabase wrapper、`@/*` import を踏襲する
-  - クライアント接続は `src/lib/supabaseClient.ts`、サーバ接続は `src/lib/supabaseAdmin.ts` を使う
+  - Supabase 接続境界は `docs/invariants.yml` の `SUPABASE_CLIENT_ADMIN_SEPARATION` を参照する
+    <!-- invariant: SUPABASE_CLIENT_ADMIN_SEPARATION -->
 - avoid speculative expansion
   - 将来必要そうという理由だけで機能、抽象化、設定項目を増やさない
   - 不明な仕様は `要確認` として止める
@@ -44,32 +45,31 @@
 
 - `page.tsx` は薄く保つ
 - UI は表示とユーザー操作を担う
-- 外部 I/O、削除権限判定、cleanup、Gemini 呼び出しは API / lib 側で扱う
-- `SUPABASE_SERVICE_ROLE_KEY` をクライアントに渡さない
-- UI から Gemini を直接呼ばない
+- 外部 I/O、削除権限判定、cleanup、Gemini 呼び出しの硬い境界は `docs/invariants.yml` を参照する
+  <!-- invariant: SERVICE_ROLE_KEY_SERVER_ONLY -->
+  <!-- invariant: AI_API_BOUNDARY -->
+  <!-- invariant: PROTECT_DELETE_CLEANUP -->
+  <!-- invariant: SUPABASE_CLIENT_ADMIN_SEPARATION -->
 
 ## データとセキュリティ
 
-- `bucket_id` は共有キー
-- `write_key` は保存・削除キー
-- `write_key_hash` はサーバ送信用
-- これらの役割を混ぜない
-- 削除と cleanup の保護条件を緩めない
-- `write_key` 平文を DB に保存しない
+- 鍵の役割、削除・cleanup、write key 保存に関する硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: KEY_ROLE_SEPARATION -->
+  <!-- invariant: WRITE_KEY_NOT_IN_DB -->
+  <!-- invariant: PROTECT_DELETE_CLEANUP -->
 
 ## AI 実装時の原則
 
-- Gemini 呼び出しは `src/app/api/polish/route.ts` に集約する
-- 入力長、mode、追加指示の検証を API 境界で維持する
-- 出力ポリシーを弱めない
-  - 事実追加禁止
-  - 固有名詞、数値、日付の改変禁止
+- AI API 境界と出力忠実性の硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: AI_API_BOUNDARY -->
+  <!-- invariant: AI_OUTPUT_FIDELITY -->
 - AI 失敗時でも保存・共有導線は継続可能にする
 
 ## PWA とキャッシュ
 
 - `public/manifest.webmanifest` と `public/sw.js` を前提にする
-- API レスポンスをキャッシュしない
+- API キャッシュの硬い条件は `docs/invariants.yml` を参照する
+  <!-- invariant: NO_SW_API_CACHE -->
 - PWA を触る変更ではホーム画面追加と起動確認まで考慮する
 
 ## ドキュメント運用

--- a/docs/invariants.yml
+++ b/docs/invariants.yml
@@ -1,0 +1,79 @@
+- id: KEY_ROLE_SEPARATION
+  statement: bucket_id / write_key / write_key_hash の役割を混在させない
+  severity: critical
+  triggers: [鍵の取得・受け渡し, env参照追加, client/admin wrapper境界, 保存・削除フロー変更]
+  rationale: 共有キー、編集キー、サーバ送信用ハッシュの混同は権限境界の破壊につながる
+  check: bucket_id は共有キー、write_key は編集キー、write_key_hash はサーバ送信用として扱われている
+  ref: AGENTS.md
+
+- id: WRITE_KEY_NOT_IN_DB
+  statement: write_key 平文を DB に保存しない
+  severity: critical
+  triggers: [保存 API 変更, Supabase insert/update 変更, DB スキーマ変更, localStorage 処理変更]
+  rationale: 平文の編集キー保存は漏洩時に保存・削除権限の侵害につながる
+  check: DB に保存される値が write_key_hash であり、write_key 平文が永続化されていない
+  ref: docs/engineering-principles.md
+
+- id: SERVICE_ROLE_KEY_SERVER_ONLY
+  statement: SUPABASE_SERVICE_ROLE_KEY をクライアントへ渡さず、UI で service role 相当処理をしない
+  severity: critical
+  triggers: [環境変数参照追加, UI 変更, Supabase 接続変更, API ルート移動]
+  rationale: service role key のクライアント露出は権限昇格とデータ漏洩に直結する
+  check: service role key はサーバ側コードのみで参照され、UI から権限処理を実行していない
+  ref: AGENTS.md
+
+- id: PROTECT_DELETE_CLEANUP
+  statement: 削除と cleanup の保護条件を緩めない
+  severity: critical
+  triggers: [削除 API 変更, cleanup API 変更, writeKeyHash 検証変更, 件数上限処理変更]
+  rationale: 保護条件の緩和は他端末・他 bucket のデータ削除につながる
+  check: 削除は id / bucketId / writeKeyHash の検証を維持し、cleanup は期限と件数上限の条件を維持している
+  ref: docs/engineering-principles.md
+
+- id: AI_OUTPUT_FIDELITY
+  statement: AI 出力で新規事実を追加せず、固有名詞・数値・日付を改変しない
+  severity: critical
+  triggers: [AI プロンプト変更, AI モード追加, 出力整形変更, Gemini モデル変更]
+  rationale: 入力にない事実や重要情報の改変はメモ内容の信頼性を壊す
+  check: AI 出力ポリシーに事実追加禁止と固有名詞・数値・日付の改変禁止が残っている
+  ref: docs/engineering-principles.md
+
+- id: AI_API_BOUNDARY
+  statement: Gemini 呼び出しは polish/route.ts に集約し、UI から直接呼ばず、入力長・mode・追加指示の検証を API 境界で維持する
+  severity: critical
+  triggers: [AI 呼び出し追加, UI 変更, API ルート変更, 入力検証変更, AI モード追加]
+  rationale: AI 接続と検証を API 境界に集約することで秘密情報と入力制約を守る
+  check: UI が Gemini を直接呼ばず、polish API で入力長・mode・追加指示を検証している
+  ref: docs/engineering-principles.md
+
+- id: SUPABASE_CLIENT_ADMIN_SEPARATION
+  statement: クライアント側は supabaseClient、サーバ側は supabaseAdmin を使い分ける
+  severity: normal
+  triggers: [Supabase 接続変更, page.tsx 変更, UI コンポーネント変更, API ルート変更]
+  rationale: クライアント接続と管理権限接続を分けることで権限境界を保つ
+  check: UI は supabaseClient、削除・cleanup などのサーバ処理は supabaseAdmin を使っている
+  ref: docs/engineering-principles.md
+
+- id: NO_SW_API_CACHE
+  statement: Service Worker で API レスポンスをキャッシュしない
+  severity: normal
+  triggers: [public/sw.js 変更, PWA キャッシュ戦略変更, API fetch ハンドリング変更]
+  rationale: API レスポンスのキャッシュは共有内容や権限状態の古い表示につながる
+  check: public/sw.js が API レスポンスを Cache Storage に保存していない
+  ref: docs/engineering-principles.md
+
+- id: CORE_LOCAL_CHANGE_ONLY
+  statement: PolishForm.tsx への変更は局所的に行い、大規模分割や再構成は別タスクで扱う
+  severity: normal
+  triggers: [PolishForm.tsx 変更, UI 責務変更, コンポーネント分割, 大規模リファクタ]
+  rationale: 中核 UI への広範な変更はレビュー困難化と回帰リスクを招く
+  check: PolishForm.tsx の変更が依頼範囲に必要な最小差分に収まっている
+  ref: AGENTS.md
+
+- id: LIMITS_STABILITY
+  statement: bucket_id 22文字以上、phrase 2000文字以内、extraInstruction 500文字以内、期限7日、1 bucket 最大200件の変更時は影響を明示する
+  severity: normal
+  triggers: [入力制限変更, cleanup 条件変更, 保存件数上限変更, AI API 検証変更, spec 変更]
+  rationale: 制約値の変更は既存データ、UX、API 検証、cleanup 動作に影響する
+  check: 制約値を変更した場合は影響範囲と関連ドキュメント更新が明記されている
+  ref: docs/ai-context.md

--- a/docs/invariants.yml
+++ b/docs/invariants.yml
@@ -11,7 +11,7 @@
   severity: critical
   triggers: [保存 API 変更, Supabase insert/update 変更, DB スキーマ変更, localStorage 処理変更]
   rationale: 平文の編集キー保存は漏洩時に保存・削除権限の侵害につながる
-  check: phrases への insert / update の引数オブジェクトが write_key_hash のみを持ち、write_key 平文キーや writeKey 変数の値が混入していない
+  check: src/components/PolishForm.tsx の supabaseClient.from("phrases").insert(...) 引数オブジェクトが write_key_hash のみを持ち、write_key 平文キーや writeKey 変数の値が混入していない(現状 phrases への update 経路はなし)
   ref: docs/engineering-principles.md
 
 - id: SERVICE_ROLE_KEY_SERVER_ONLY
@@ -35,7 +35,7 @@
   severity: critical
   triggers: [AI プロンプト変更, AI モード追加, 出力整形変更, Gemini モデル変更]
   rationale: 入力にない事実や重要情報の改変はメモ内容の信頼性を壊す
-  check: fullPrompt 冒頭の事実不追加・固有名詞/数値/日付の不改変ブロックと続き生成プロンプトの同等文言が全モードで維持され、新モード追加時も同じ制約が instruction に入っている
+  check: AI モードの追加・変更 diff で modeInstruction または共通プロンプト(fullPrompt)に事実不追加・固有名詞/数値/日付の不改変制約が含まれ、既存モードの当該制約文が削除されていない
   ref: docs/engineering-principles.md
 
 - id: AI_API_BOUNDARY
@@ -67,7 +67,7 @@
   severity: normal
   triggers: [PolishForm.tsx 変更, UI 責務変更, コンポーネント分割, 大規模リファクタ]
   rationale: 中核 UI への広範な変更はレビュー困難化と回帰リスクを招く
-  check: 変更が PolishForm.tsx 内の局所差分にとどまり、src/components 配下への新規分割ファイル作成や関数の大規模な別ファイル移動・宣言順の大幅な入れ替えを伴っていない(大規模分割は別タスク)
+  check: 変更が src/components 配下への新規分割ファイル作成や、PolishForm.tsx の関数を別ファイルへ移動する大規模分割・再構成を伴っていない(大規模分割は別タスク)
   ref: AGENTS.md
 
 - id: LIMITS_STABILITY
@@ -75,5 +75,5 @@
   severity: normal
   triggers: [入力制限変更, cleanup 条件変更, 保存件数上限変更, AI API 検証変更, spec 変更]
   rationale: 制約値の変更は既存データ、UX、API 検証、cleanup 動作に影響する
-  check: phraseConstraints.ts の定数変更時に影響範囲(UI 表示 / validation / cleanup / DB)が diff かコメントで明示され、制約値が定数 import でなくマジックナンバー(2000 / 500 / 200 / 22 / 7)でハードコードされていない
+  check: phraseConstraints.ts のエクスポート定数を変更する diff で影響範囲(UI / validation / cleanup / DB)が明示され、制約値が定数 import でなく新規マジックナンバーとしてハードコードされていない
   ref: docs/ai-context.md

--- a/docs/invariants.yml
+++ b/docs/invariants.yml
@@ -3,7 +3,7 @@
   severity: critical
   triggers: [鍵の取得・受け渡し, env参照追加, client/admin wrapper境界, 保存・削除フロー変更]
   rationale: 共有キー、編集キー、サーバ送信用ハッシュの混同は権限境界の破壊につながる
-  check: bucket_id は共有キー、write_key は編集キー、write_key_hash はサーバ送信用として扱われている
+  check: write_key 平文が fetch ボディや DB insert に渡る経路がなく、writeKeyHash と bucketId が別フィールドのまま、hashSha256 によるハッシュ化が迂回されていない
   ref: AGENTS.md
 
 - id: WRITE_KEY_NOT_IN_DB
@@ -11,7 +11,7 @@
   severity: critical
   triggers: [保存 API 変更, Supabase insert/update 変更, DB スキーマ変更, localStorage 処理変更]
   rationale: 平文の編集キー保存は漏洩時に保存・削除権限の侵害につながる
-  check: DB に保存される値が write_key_hash であり、write_key 平文が永続化されていない
+  check: phrases への insert / update の引数オブジェクトが write_key_hash のみを持ち、write_key 平文キーや writeKey 変数の値が混入していない
   ref: docs/engineering-principles.md
 
 - id: SERVICE_ROLE_KEY_SERVER_ONLY
@@ -19,7 +19,7 @@
   severity: critical
   triggers: [環境変数参照追加, UI 変更, Supabase 接続変更, API ルート移動]
   rationale: service role key のクライアント露出は権限昇格とデータ漏洩に直結する
-  check: service role key はサーバ側コードのみで参照され、UI から権限処理を実行していない
+  check: client component や src/components 配下が supabaseAdmin や SUPABASE_SERVICE_ROLE_KEY を import / 参照せず、SUPABASE_SERVICE_ROLE_KEY に NEXT_PUBLIC_ プレフィックスが付与されていない
   ref: AGENTS.md
 
 - id: PROTECT_DELETE_CLEANUP
@@ -27,7 +27,7 @@
   severity: critical
   triggers: [削除 API 変更, cleanup API 変更, writeKeyHash 検証変更, 件数上限処理変更]
   rationale: 保護条件の緩和は他端末・他 bucket のデータ削除につながる
-  check: 削除は id / bucketId / writeKeyHash の検証を維持し、cleanup は期限と件数上限の条件を維持している
+  check: delete が id / bucketId / writeKeyHash の形式検証と .eq("write_key_hash") 照合を維持し、cleanup が期限切れ条件(expires_at)・件数上限・writeKeyHash 照合をいずれも維持している
   ref: docs/engineering-principles.md
 
 - id: AI_OUTPUT_FIDELITY
@@ -35,7 +35,7 @@
   severity: critical
   triggers: [AI プロンプト変更, AI モード追加, 出力整形変更, Gemini モデル変更]
   rationale: 入力にない事実や重要情報の改変はメモ内容の信頼性を壊す
-  check: AI 出力ポリシーに事実追加禁止と固有名詞・数値・日付の改変禁止が残っている
+  check: fullPrompt 冒頭の事実不追加・固有名詞/数値/日付の不改変ブロックと続き生成プロンプトの同等文言が全モードで維持され、新モード追加時も同じ制約が instruction に入っている
   ref: docs/engineering-principles.md
 
 - id: AI_API_BOUNDARY
@@ -43,7 +43,7 @@
   severity: critical
   triggers: [AI 呼び出し追加, UI 変更, API ルート変更, 入力検証変更, AI モード追加]
   rationale: AI 接続と検証を API 境界に集約することで秘密情報と入力制約を守る
-  check: UI が Gemini を直接呼ばず、polish API で入力長・mode・追加指示を検証している
+  check: Client Component が @google/generative-ai を import せず GEMINI_API_KEY を NEXT_PUBLIC_ で公開しておらず、route.ts の text 長 / mode ホワイトリスト / extraInstruction 長の検証が削除されていない
   ref: docs/engineering-principles.md
 
 - id: SUPABASE_CLIENT_ADMIN_SEPARATION
@@ -51,7 +51,7 @@
   severity: normal
   triggers: [Supabase 接続変更, page.tsx 変更, UI コンポーネント変更, API ルート変更]
   rationale: クライアント接続と管理権限接続を分けることで権限境界を保つ
-  check: UI は supabaseClient、削除・cleanup などのサーバ処理は supabaseAdmin を使っている
+  check: src/components は supabaseClient のみ、src/app/api の delete / cleanup は supabaseAdmin のみを使い、両者の import 元が入れ替わっていない
   ref: docs/engineering-principles.md
 
 - id: NO_SW_API_CACHE
@@ -59,7 +59,7 @@
   severity: normal
   triggers: [public/sw.js 変更, PWA キャッシュ戦略変更, API fetch ハンドリング変更]
   rationale: API レスポンスのキャッシュは共有内容や権限状態の古い表示につながる
-  check: public/sw.js が API レスポンスを Cache Storage に保存していない
+  check: sw.js の isCacheAllowed が /api/ を除外し続け、/api/ が PRECACHE_URLS やキャッシュ許可集合に追加されておらず、isCacheAllowed を経由しない cache.put が追加されていない
   ref: docs/engineering-principles.md
 
 - id: CORE_LOCAL_CHANGE_ONLY
@@ -67,7 +67,7 @@
   severity: normal
   triggers: [PolishForm.tsx 変更, UI 責務変更, コンポーネント分割, 大規模リファクタ]
   rationale: 中核 UI への広範な変更はレビュー困難化と回帰リスクを招く
-  check: PolishForm.tsx の変更が依頼範囲に必要な最小差分に収まっている
+  check: 変更が PolishForm.tsx 内の局所差分にとどまり、src/components 配下への新規分割ファイル作成や関数の大規模な別ファイル移動・宣言順の大幅な入れ替えを伴っていない(大規模分割は別タスク)
   ref: AGENTS.md
 
 - id: LIMITS_STABILITY
@@ -75,5 +75,5 @@
   severity: normal
   triggers: [入力制限変更, cleanup 条件変更, 保存件数上限変更, AI API 検証変更, spec 変更]
   rationale: 制約値の変更は既存データ、UX、API 検証、cleanup 動作に影響する
-  check: 制約値を変更した場合は影響範囲と関連ドキュメント更新が明記されている
+  check: phraseConstraints.ts の定数変更時に影響範囲(UI 表示 / validation / cleanup / DB)が diff かコメントで明示され、制約値が定数 import でなくマジックナンバー(2000 / 500 / 200 / 22 / 7)でハードコードされていない
   ref: docs/ai-context.md

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -71,6 +71,8 @@ path は workspace root 基準の repository relative path で読む。
   - 仕様の正本に近い文書
 - [`docs/app-overview.md`](./app-overview.md)
   - データの流れと責務の説明
+- [`docs/invariants.yml`](./invariants.yml)
+  - repo 固有の硬い不変条件の正本
 - [`dev-instruction.md`](../dev-instruction.md)
   - ピボット背景と UX 要件
 - [`tech-stack.md`](../tech-stack.md)


### PR DESCRIPTION
## 概要
repo 固有の「硬い不変条件」を単一ソース化し、pre-flight / review skill の入力契約にする doc 変更。**src 変更なし**。

### 含む内容
- `docs/invariants.yml` を新設し、硬い不変条件10件を正本化(severity / triggers / rationale / check / ref)
- `AGENTS.md` / `docs/engineering-principles.md` / `docs/ai-context.md` の重複本文を ID 参照(+ `<!-- invariant: ID -->` コメントで双方向 grep 可能)に整理。柔らかい判断指針は prose のまま据え置き
- `check` フィールドを「文書存在チェック」から「diff が満たすべき behavioral アサーション」へ書き換え(実コードのシグナルに根ざす)

### 検証
- YAML parse(js-yaml)通過、10件・必須フィールド維持
- 敵対的セルフレビュー + ドライラン(critical違反/clean/no-op の3シナリオ)+ Codex 独立レビュー(マージ可判定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)