### PR TITLE
Fix cleanup phrase max count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+docs/secret-rotation-vercel-2026-04.md

--- a/src/app/api/phrases/cleanup/route.ts
+++ b/src/app/api/phrases/cleanup/route.ts
@@ -7,7 +7,6 @@ import { hasSupabaseAdminConfig, supabaseAdmin } from "@/lib/supabaseAdmin";
 type CleanupPayload = {
   bucketId?: string;
   writeKeyHash?: string;
-  maxPhraseCount?: number;
 };
 
 export async function POST(request: Request) {
@@ -26,10 +25,7 @@ export async function POST(request: Request) {
   }
 
   const { bucketId, writeKeyHash } = payload;
-  const maxCount =
-    typeof payload.maxPhraseCount === "number" && payload.maxPhraseCount > 0
-      ? payload.maxPhraseCount
-      : phraseMaxCount;
+  const maxCount = phraseMaxCount;
 
   if (!bucketId || !writeKeyHash) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- Enforce the server-side cleanup phrase max count constant instead of accepting a request-provided max count.
- Ignore the local secret rotation note path so it is not accidentally tracked.

## Why
The cleanup API should not allow clients to override the phrase retention limit. Keeping the limit fixed at the shared constraint preserves the expected bucket cleanup behavior.

## Validation
- `npm test`
- `npm run lint`
- `npm run build`