### PR TITLE
[codex] add supabase keep-alive endpoint

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -3,6 +3,7 @@ name: Supabase keep-alive
 on:
   schedule:
     - cron: "17 0 * * *"
+    - cron: "17 12 * * *"
   workflow_dispatch:
 
 jobs:
@@ -11,7 +12,14 @@ jobs:
     steps:
       - name: Call keep-alive endpoint
         env:
-          KEEPALIVE_URL: ${{ vars.KEEPALIVE_URL || secrets.KEEPALIVE_URL }}
+          KEEPALIVE_URL: ${{ secrets.KEEPALIVE_URL }}
+          KEEPALIVE_TOKEN: ${{ secrets.KEEPALIVE_TOKEN }}
         run: |
           test -n "$KEEPALIVE_URL"
-          curl --fail --show-error --silent "$KEEPALIVE_URL/api/keepalive"
+          if [ -n "$KEEPALIVE_TOKEN" ]; then
+            curl --fail --show-error --silent \
+              --header "Authorization: Bearer $KEEPALIVE_TOKEN" \
+              "$KEEPALIVE_URL/api/keepalive"
+          else
+            curl --fail --show-error --silent "$KEEPALIVE_URL/api/keepalive"
+          fi

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,17 @@
+name: Supabase keep-alive
+
+on:
+  schedule:
+    - cron: "17 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call keep-alive endpoint
+        env:
+          KEEPALIVE_URL: ${{ vars.KEEPALIVE_URL || secrets.KEEPALIVE_URL }}
+        run: |
+          test -n "$KEEPALIVE_URL"
+          curl --fail --show-error --silent "$KEEPALIVE_URL/api/keepalive"

--- a/README.md
+++ b/README.md
@@ -55,9 +55,24 @@ npm run dev
 ## 開発スクリプト
 
 - `npm run dev`
+- `npm test`
 - `npm run build`
 - `npm run start`
 - `npm run lint`
+
+## Supabase keep-alive
+
+Supabase 無料プロジェクトの pause 回避用に、`GET /api/keepalive` を用意しています。  
+この API は anon key の `supabaseClient` で `phrases` を 1 件だけ読み取り、成功時に `{ "ok": true }` を返します。service role は使いません。
+
+GitHub Actions の `.github/workflows/keepalive.yml` は日次 cron と手動実行に対応しています。  
+Repository Variables または Repository Secrets に `KEEPALIVE_URL` を設定してください。
+
+例:
+
+```text
+KEEPALIVE_URL=https://your-production-domain.example
+```
 
 ## PWA 確認手順
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
 SUPABASE_URL=YOUR_SUPABASE_URL
 SUPABASE_SERVICE_ROLE_KEY=YOUR_SUPABASE_SERVICE_ROLE_KEY
 
+# 任意: keep-alive API を Bearer token で保護する
+KEEPALIVE_TOKEN=YOUR_KEEPALIVE_TOKEN
+
 # Gemini API
 GEMINI_API_KEY=YOUR_GEMINI_API_KEY
 ```
@@ -66,12 +69,13 @@ Supabase 無料プロジェクトの pause 回避用に、`GET /api/keepalive` �
 この API は anon key の `supabaseClient` で `phrases` を 1 件だけ読み取り、成功時に `{ "ok": true }` を返します。service role は使いません。
 
 GitHub Actions の `.github/workflows/keepalive.yml` は日次 cron と手動実行に対応しています。  
-Repository Variables または Repository Secrets に `KEEPALIVE_URL` を設定してください。
+Repository Secrets に `KEEPALIVE_URL` を設定してください。任意で `KEEPALIVE_TOKEN` を設定すると、workflow は `Authorization: Bearer ...` を付けて呼び出します。
 
 例:
 
 ```text
 KEEPALIVE_URL=https://your-production-domain.example
+KEEPALIVE_TOKEN=your-random-token
 ```
 
 ## PWA 確認手順

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -1,21 +1,29 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-import { buildKeepaliveResponse } from "@/lib/keepalive";
+import { buildKeepaliveResponse, isKeepaliveAuthorized } from "@/lib/keepalive";
 import { hasSupabaseConfig, supabaseClient } from "@/lib/supabaseClient";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  const configResponse = buildKeepaliveResponse({ hasConfig: hasSupabaseConfig });
-
-  if (!hasSupabaseConfig || !supabaseClient) {
-    return NextResponse.json(configResponse.body, { status: configResponse.status });
+export async function GET(request: NextRequest) {
+  if (
+    !isKeepaliveAuthorized({
+      authorizationHeader: request.headers.get("authorization"),
+      token: process.env.KEEPALIVE_TOKEN,
+    })
+  ) {
+    return NextResponse.json({ ok: false }, { status: 401 });
   }
 
-  const { error } = await supabaseClient.from("phrases").select("id").limit(1);
+  if (!hasSupabaseConfig || !supabaseClient) {
+    const response = buildKeepaliveResponse({ hasConfig: false });
+    return NextResponse.json(response.body, { status: response.status });
+  }
+
+  const { data, error } = await supabaseClient.from("phrases").select("id").limit(1);
   const response = buildKeepaliveResponse({
     hasConfig: true,
-    hasQueryError: Boolean(error),
+    hasQueryError: Boolean(error) || data === null,
   });
 
   if (error) {

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { buildKeepaliveResponse } from "@/lib/keepalive";
+import { hasSupabaseConfig, supabaseClient } from "@/lib/supabaseClient";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const configResponse = buildKeepaliveResponse({ hasConfig: hasSupabaseConfig });
+
+  if (!hasSupabaseConfig || !supabaseClient) {
+    return NextResponse.json(configResponse.body, { status: configResponse.status });
+  }
+
+  const { error } = await supabaseClient.from("phrases").select("id").limit(1);
+  const response = buildKeepaliveResponse({
+    hasConfig: true,
+    hasQueryError: Boolean(error),
+  });
+
+  if (error) {
+    console.error("Failed to keep Supabase alive:", error);
+  }
+
+  return NextResponse.json(response.body, { status: response.status });
+}

--- a/src/lib/keepalive.ts
+++ b/src/lib/keepalive.ts
@@ -12,6 +12,20 @@ type BuildKeepaliveResponseParams = {
   hasQueryError?: boolean;
 };
 
+export function isKeepaliveAuthorized({
+  authorizationHeader,
+  token,
+}: {
+  authorizationHeader: string | null;
+  token?: string;
+}): boolean {
+  if (!token) {
+    return true;
+  }
+
+  return authorizationHeader === `Bearer ${token}`;
+}
+
 export function buildKeepaliveResponse({
   hasConfig,
   hasQueryError = false,

--- a/src/lib/keepalive.ts
+++ b/src/lib/keepalive.ts
@@ -1,0 +1,37 @@
+export type KeepaliveBody = {
+  ok: boolean;
+};
+
+export type KeepaliveResponse = {
+  body: KeepaliveBody;
+  status: number;
+};
+
+type BuildKeepaliveResponseParams = {
+  hasConfig: boolean;
+  hasQueryError?: boolean;
+};
+
+export function buildKeepaliveResponse({
+  hasConfig,
+  hasQueryError = false,
+}: BuildKeepaliveResponseParams): KeepaliveResponse {
+  if (!hasConfig) {
+    return {
+      body: { ok: false },
+      status: 503,
+    };
+  }
+
+  if (hasQueryError) {
+    return {
+      body: { ok: false },
+      status: 500,
+    };
+  }
+
+  return {
+    body: { ok: true },
+    status: 200,
+  };
+}

--- a/test/keepalive.test.ts
+++ b/test/keepalive.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import { buildKeepaliveResponse } from "../src/lib/keepalive.ts";
+
+export const keepaliveTests: Array<{ name: string; run: () => void }> = [
+  {
+    name: "buildKeepaliveResponse は設定不足時に 503 と ok false を返す",
+    run: () => {
+      assert.deepEqual(buildKeepaliveResponse({ hasConfig: false }), {
+        body: { ok: false },
+        status: 503,
+      });
+    },
+  },
+  {
+    name: "buildKeepaliveResponse は query 成功時に 200 と ok true を返す",
+    run: () => {
+      assert.deepEqual(buildKeepaliveResponse({ hasConfig: true }), {
+        body: { ok: true },
+        status: 200,
+      });
+    },
+  },
+  {
+    name: "buildKeepaliveResponse は query 失敗時に 500 と ok false を返す",
+    run: () => {
+      assert.deepEqual(
+        buildKeepaliveResponse({ hasConfig: true, hasQueryError: true }),
+        {
+          body: { ok: false },
+          status: 500,
+        },
+      );
+    },
+  },
+];

--- a/test/keepalive.test.ts
+++ b/test/keepalive.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { buildKeepaliveResponse } from "../src/lib/keepalive.ts";
+import {
+  buildKeepaliveResponse,
+  isKeepaliveAuthorized,
+} from "../src/lib/keepalive.ts";
 
 export const keepaliveTests: Array<{ name: string; run: () => void }> = [
   {
@@ -30,6 +33,34 @@ export const keepaliveTests: Array<{ name: string; run: () => void }> = [
           body: { ok: false },
           status: 500,
         },
+      );
+    },
+  },
+  {
+    name: "isKeepaliveAuthorized は token 未設定時に許可する",
+    run: () => {
+      assert.equal(
+        isKeepaliveAuthorized({ authorizationHeader: null, token: undefined }),
+        true,
+      );
+    },
+  },
+  {
+    name: "isKeepaliveAuthorized は token 設定時に Bearer token を要求する",
+    run: () => {
+      assert.equal(
+        isKeepaliveAuthorized({
+          authorizationHeader: "Bearer expected-token",
+          token: "expected-token",
+        }),
+        true,
+      );
+      assert.equal(
+        isKeepaliveAuthorized({
+          authorizationHeader: "Bearer wrong-token",
+          token: "expected-token",
+        }),
+        false,
       );
     },
   },

--- a/test/run-tests.ts
+++ b/test/run-tests.ts
@@ -1,4 +1,5 @@
 import { phraseValidationTests } from "./phraseValidation.test.ts";
+import { keepaliveTests } from "./keepalive.test.ts";
 import { urlTextTests } from "./urlText.test.ts";
 
 type TestCase = {
@@ -6,7 +7,7 @@ type TestCase = {
   run: () => void;
 };
 
-const tests: TestCase[] = [...phraseValidationTests, ...urlTextTests];
+const tests: TestCase[] = [...phraseValidationTests, ...keepaliveTests, ...urlTextTests];
 
 let passed = 0;
 


### PR DESCRIPTION
## Summary
- Add `GET /api/keepalive` to touch Supabase with the anon `supabaseClient` and return `{ ok: true }` on success.
- Add pure response/auth helper logic in `src/lib/keepalive.ts` with tests for success, missing config, query failure, and optional Bearer token branches.
- Add a twice-daily/manual GitHub Actions workflow that calls the production keep-alive endpoint via `KEEPALIVE_URL` from Repository Secrets.
- Document the keep-alive setup and optional `KEEPALIVE_TOKEN` protection in `README.md`.

Closes #16

## Validation
- `npm test` passed: 17/17 tests.
- `npm run lint` passed.
- `npm run build` passed.
- Invariant review passed for `SERVICE_ROLE_KEY_SERVER_ONLY`, `SUPABASE_CLIENT_ADMIN_SEPARATION`, and `KEY_ROLE_SEPARATION`.
- Local `GET /api/keepalive` with missing Supabase env returned `503 {"ok":false}` in the previous validation pass.

## Notes
- Local `GET /api/keepalive` with the current `.env.local` reached the route but returned `500 {"ok":false}` because Supabase reported `Unregistered API key`. A 200 response should be verified after updating the local/deployed anon key or running against the configured production project.
- Review threads were addressed in commit `a210e6b`; I did not resolve GitHub review threads automatically.