### PR TITLE
[codex] /api/polish にレート制限を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,36 @@ Supabase や Gemini の実接続確認ができない場合は、その旨を明
   <!-- invariant: AI_OUTPUT_FIDELITY -->
   <!-- invariant: NO_SW_API_CACHE -->
 
+## Review Setup
+
+このリポジトリの Claude コードレビューの effort は `docs/review.yml` で管理する。
+
+```yaml
+effort: fast   # fast | standard
+```
+
+- `fast` — Claude がインラインで diff を読み判断（agent 不使用、~20-40k tokens）
+- `standard` — 3 finder agents + verifier agents（~70-100k tokens）
+- セキュリティ境界・認証・削除系の変更のみ bundled `/code-review`（thorough、~250k+）を使用
+
+新しいリポジトリでこのレビューフローを使う場合は `docs/review.yml` を追加するだけでよい。
+skill 本体は `E:\apps\.agents\skills\code-review\SKILL.md` にワークスペース共通で置いてある。
+
+## PR Review Monitoring
+
+この repo では、PR 作成後と push 更新後に Claude review の監視を行う。
+
+- PR 作成直後に repo root の `.review-inbox` へ PR 番号を書き込む
+- push して PR を更新した後も、同じ PR 番号を `.review-inbox` へ再度書き込む
+- GitHub コメントを確認し、`claude-review` を含む最新コメントがあれば内容を読んで対応する
+- 指摘に対応したら `npm test` / `npm run lint` / `npm run build` を実行する
+- 対応コミットを push したら、再度 `.review-inbox` を更新する
+- 監視は原則 5 分おき、最大 8 回まで行う
+- `LGTM` または対応不要が確認できたら完了とする
+- 最大回数に達した場合は、未完了として状況を報告する
+
+`.review-inbox` はローカル連携用ファイルであり、git 管理に含めない。
+
 ## Environment Variables
 この repo で前提となる環境変数:
 

--- a/docs/review.yml
+++ b/docs/review.yml
@@ -1,0 +1,1 @@
+effort: fast

--- a/spec.md
+++ b/spec.md
@@ -102,6 +102,7 @@ AI 加工（推敲 / 敬語化 / 要点抽出）は任意機能で、通常の�
   - request: `{ text, mode, extraInstruction? }`
   - `text` は 2000 文字以内、`extraInstruction` は 500 文字以内
   - mode: `polish | keigo | keypoints`
+  - `x-vercel-forwarded-for` / `x-real-ip` を使う IP ベースの簡易レート制限を行い、上限超過時は 429 と日本語エラーを返す
 - `POST /api/phrases/delete`（削除）
 - `POST /api/phrases/cleanup`（200件整理）
 

--- a/src/app/api/polish/route.ts
+++ b/src/app/api/polish/route.ts
@@ -2,8 +2,18 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 import { validateExtraInstruction, validatePhraseText } from "@/lib/phraseValidation";
+import {
+  checkRateLimit,
+  getTrustedClientIp,
+  polishRateLimitMaxRequests,
+  polishRateLimitWindowMs,
+  pruneExpiredRateLimitBuckets,
+  type RateLimitBucket,
+} from "@/lib/rateLimit";
 
 const geminiApiKey = process.env.GEMINI_API_KEY ?? "";
+const polishRateLimitBuckets = new Map<string, RateLimitBucket>();
+let polishRateLimitLastPrunedAt = 0;
 
 type PolishMode = "polish" | "keigo" | "keypoints";
 
@@ -61,6 +71,43 @@ export async function POST(request: Request) {
             error: extraInstructionValidationError,
           },
           { status: 400 }
+        );
+      }
+    }
+
+    const now = Date.now();
+    if (now - polishRateLimitLastPrunedAt >= polishRateLimitWindowMs) {
+      const activeBuckets = pruneExpiredRateLimitBuckets({
+        entries: [...polishRateLimitBuckets.entries()],
+        now,
+        windowMs: polishRateLimitWindowMs,
+      });
+      polishRateLimitBuckets.clear();
+      for (const [ip, bucket] of activeBuckets) {
+        polishRateLimitBuckets.set(ip, bucket);
+      }
+      polishRateLimitLastPrunedAt = now;
+    }
+
+    const clientIp = getTrustedClientIp(request.headers);
+    if (clientIp) {
+      const rateLimitResult = checkRateLimit({
+        currentBucket: polishRateLimitBuckets.get(clientIp),
+        maxRequests: polishRateLimitMaxRequests,
+        now,
+        windowMs: polishRateLimitWindowMs,
+      });
+      polishRateLimitBuckets.set(clientIp, rateLimitResult.bucket);
+
+      if (!rateLimitResult.allowed) {
+        return NextResponse.json(
+          { error: "AI加工の利用回数が一時的に上限に達しました。しばらくして再試行してください。" },
+          {
+            headers: {
+              "Retry-After": String(rateLimitResult.retryAfterSeconds),
+            },
+            status: 429,
+          }
         );
       }
     }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,73 @@
+export type RateLimitBucket = {
+  count: number;
+  windowStartedAt: number;
+};
+
+export type RateLimitResult = {
+  allowed: boolean;
+  bucket: RateLimitBucket;
+  retryAfterSeconds?: number;
+};
+
+export const polishRateLimitMaxRequests = 10;
+export const polishRateLimitWindowMs = 60 * 1000;
+
+function firstHeaderValue(value: string | null): string | undefined {
+  return value?.split(",")[0]?.trim() || undefined;
+}
+
+export function getTrustedClientIp(headers: Headers): string | undefined {
+  return (
+    firstHeaderValue(headers.get("x-vercel-forwarded-for")) ??
+    firstHeaderValue(headers.get("x-real-ip"))
+  );
+}
+
+export function pruneExpiredRateLimitBuckets(params: {
+  entries: Array<[string, RateLimitBucket]>;
+  now: number;
+  windowMs: number;
+}): Array<[string, RateLimitBucket]> {
+  const { entries, now, windowMs } = params;
+  return entries.filter(([, bucket]) => now - bucket.windowStartedAt < windowMs);
+}
+
+export function checkRateLimit(params: {
+  currentBucket?: RateLimitBucket;
+  maxRequests: number;
+  now: number;
+  windowMs: number;
+}): RateLimitResult {
+  const { currentBucket, maxRequests, now, windowMs } = params;
+
+  if (!currentBucket || now - currentBucket.windowStartedAt >= windowMs) {
+    return {
+      allowed: true,
+      bucket: {
+        count: 1,
+        windowStartedAt: now,
+      },
+    };
+  }
+
+  if (currentBucket.count >= maxRequests) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((currentBucket.windowStartedAt + windowMs - now) / 1000),
+    );
+
+    return {
+      allowed: false,
+      bucket: currentBucket,
+      retryAfterSeconds,
+    };
+  }
+
+  return {
+    allowed: true,
+    bucket: {
+      count: currentBucket.count + 1,
+      windowStartedAt: currentBucket.windowStartedAt,
+    },
+  };
+}

--- a/test/rateLimit.test.ts
+++ b/test/rateLimit.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+
+import {
+  checkRateLimit,
+  getTrustedClientIp,
+  polishRateLimitMaxRequests,
+  polishRateLimitWindowMs,
+  pruneExpiredRateLimitBuckets,
+} from "../src/lib/rateLimit.ts";
+
+export const rateLimitTests: Array<{ name: string; run: () => void }> = [
+  {
+    name: "checkRateLimit は初回リクエストを許可する",
+    run: () => {
+      assert.deepEqual(
+        checkRateLimit({
+          maxRequests: polishRateLimitMaxRequests,
+          now: 1000,
+          windowMs: polishRateLimitWindowMs,
+        }),
+        {
+          allowed: true,
+          bucket: {
+            count: 1,
+            windowStartedAt: 1000,
+          },
+        },
+      );
+    },
+  },
+  {
+    name: "checkRateLimit は上限未満ならカウントを増やして許可する",
+    run: () => {
+      assert.deepEqual(
+        checkRateLimit({
+          currentBucket: {
+            count: polishRateLimitMaxRequests - 1,
+            windowStartedAt: 1000,
+          },
+          maxRequests: polishRateLimitMaxRequests,
+          now: 2000,
+          windowMs: polishRateLimitWindowMs,
+        }),
+        {
+          allowed: true,
+          bucket: {
+            count: polishRateLimitMaxRequests,
+            windowStartedAt: 1000,
+          },
+        },
+      );
+    },
+  },
+  {
+    name: "checkRateLimit は上限到達時に拒否し retryAfterSeconds を返す",
+    run: () => {
+      assert.deepEqual(
+        checkRateLimit({
+          currentBucket: {
+            count: polishRateLimitMaxRequests,
+            windowStartedAt: 1000,
+          },
+          maxRequests: polishRateLimitMaxRequests,
+          now: 31_000,
+          windowMs: polishRateLimitWindowMs,
+        }),
+        {
+          allowed: false,
+          bucket: {
+            count: polishRateLimitMaxRequests,
+            windowStartedAt: 1000,
+          },
+          retryAfterSeconds: 30,
+        },
+      );
+    },
+  },
+  {
+    name: "checkRateLimit はウィンドウ経過後にカウントをリセットする",
+    run: () => {
+      assert.deepEqual(
+        checkRateLimit({
+          currentBucket: {
+            count: polishRateLimitMaxRequests,
+            windowStartedAt: 1000,
+          },
+          maxRequests: polishRateLimitMaxRequests,
+          now: 1000 + polishRateLimitWindowMs,
+          windowMs: polishRateLimitWindowMs,
+        }),
+        {
+          allowed: true,
+          bucket: {
+            count: 1,
+            windowStartedAt: 1000 + polishRateLimitWindowMs,
+          },
+        },
+      );
+    },
+  },
+  {
+    name: "getTrustedClientIp は x-vercel-forwarded-for の先頭値を返す",
+    run: () => {
+      const headers = new Headers({
+        "x-vercel-forwarded-for": "203.0.113.1, 198.51.100.2",
+        "x-forwarded-for": "203.0.113.1, 198.51.100.2",
+        "x-real-ip": "198.51.100.3",
+      });
+
+      assert.equal(getTrustedClientIp(headers), "203.0.113.1");
+    },
+  },
+  {
+    name: "getTrustedClientIp は x-real-ip へフォールバックし x-forwarded-for を信頼しない",
+    run: () => {
+      assert.equal(getTrustedClientIp(new Headers({ "x-real-ip": "198.51.100.3" })), "198.51.100.3");
+      assert.equal(getTrustedClientIp(new Headers({ "x-forwarded-for": "203.0.113.1" })), undefined);
+      assert.equal(getTrustedClientIp(new Headers()), undefined);
+    },
+  },
+  {
+    name: "pruneExpiredRateLimitBuckets は期限切れバケットを除外する",
+    run: () => {
+      assert.deepEqual(
+        pruneExpiredRateLimitBuckets({
+          entries: [
+            ["active", { count: 1, windowStartedAt: 10_000 }],
+            ["expired", { count: 1, windowStartedAt: 1_000 }],
+          ],
+          now: 10_000 + polishRateLimitWindowMs - 1,
+          windowMs: polishRateLimitWindowMs,
+        }),
+        [["active", { count: 1, windowStartedAt: 10_000 }]],
+      );
+    },
+  },
+];

--- a/test/run-tests.ts
+++ b/test/run-tests.ts
@@ -1,6 +1,7 @@
 import { phraseValidationTests } from "./phraseValidation.test.ts";
 import { keepaliveTests } from "./keepalive.test.ts";
 import { qrPairingTests } from "./qrPairing.test.ts";
+import { rateLimitTests } from "./rateLimit.test.ts";
 import { shareParamsTests } from "./shareParams.test.ts";
 import { urlTextTests } from "./urlText.test.ts";
 
@@ -13,6 +14,7 @@ const tests: TestCase[] = [
   ...phraseValidationTests,
   ...keepaliveTests,
   ...qrPairingTests,
+  ...rateLimitTests,
   ...shareParamsTests,
   ...urlTextTests,
 ];


### PR DESCRIPTION
## 概要

- `/api/polish` に IP ベースの簡易レート制限を追加しました
- レート制限の判定ロジックを `src/lib/rateLimit.ts` の純関数として切り出しました
- 上限超過時は 429 と日本語エラーメッセージ、`Retry-After` ヘッダーを返します
- `AGENTS.md` に PR Review Monitoring を追加し、`docs/review.yml` で Claude review effort を管理する運用ルールも同梱しました

## 実装メモ

- IP は `x-vercel-forwarded-for` の先頭値を優先し、なければ `x-real-ip` へフォールバックします
- クライアントが偽装しやすい汎用 `x-forwarded-for` はバケットキーに使いません
- 信頼できる IP ヘッダーが取れない場合は、誤って全員を `unknown` バケットに集約しないようレート制限をスキップします
- 期限切れバケットはウィンドウ単位で prune します
- MVP としてメモリ内固定ウィンドウ方式です。サーバレス複数インスタンスでは厳密な全体制限ではない前提です
- 既存の `text` 長、`mode` ホワイトリスト、`extraInstruction` 長の検証は維持しています
- Gemini プロンプトと出力ポリシーは変更していません

## レビュー対応

- `x-forwarded-for` スプーフィングでの制限回避を避けるため、信頼寄りのヘッダーだけを採用するよう修正しました
- `unknown` バケット共有による誤 429 を避けるため、IP 不明時は制限対象外にしました
- Map の期限切れエントリを prune する処理とテストを追加しました
- メモリ内 Map がサーバレス複数インスタンスで共有されない点は、issue の MVP 方針どおり設計上の割り切りとして明記しています

## 確認

- `npm test` 通過（39/39）
- `npm run lint` 通過
- `npm run build` 通過

## 手動確認

- 連続実行で 429、時間経過後に回復する確認は未実施です（API 実接続確認が必要なため）

Closes #20